### PR TITLE
feat(ui): add EditList screen and improve EditInput with password toggle

### DIFF
--- a/PlainText/app/build.gradle.kts
+++ b/PlainText/app/build.gradle.kts
@@ -74,6 +74,8 @@ dependencies {
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
+
+    implementation("androidx.compose.material:material-icons-extended")
 }
 
 hilt {

--- a/PlainText/app/src/main/java/com/example/plaintext/ui/screens/editList/EditList.kt
+++ b/PlainText/app/src/main/java/com/example/plaintext/ui/screens/editList/EditList.kt
@@ -1,5 +1,6 @@
 package com.example.plaintext.ui.screens.editList
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -12,12 +13,20 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
@@ -27,62 +36,225 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.plaintext.data.model.PasswordInfo
 import com.example.plaintext.ui.screens.Screen
 import com.example.plaintext.ui.screens.login.TopBarComponent
+import com.example.plaintext.ui.screens.util.MyTopBar
+import com.example.plaintext.ui.theme.*
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+
+
+enum class PasswordFormMode { CREATE, EDIT }
 
 data class EditListState(
-    val nomeState: MutableState<String>,
-    val usuarioState: MutableState<String>,
-    val senhaState: MutableState<String>,
-    val notasState: MutableState<String>,
+    val name: String = "",
+    val user: String = "",
+    val password: String = "",
+    val notes: String = ""
 )
 
 fun isPasswordEmpty(password: PasswordInfo): Boolean {
-    return password.name.isEmpty() && password.login.isEmpty() && password.password.isEmpty() && password.notes.isEmpty()
+    return  password.name.isEmpty() &&
+            password.login.isEmpty() &&
+            password.password.isEmpty() &&
+            password.notes.isEmpty()
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun EditList(
     args: Screen.EditList,
     navigateBack: () -> Unit,
     savePassword: (password: PasswordInfo) -> Unit
 ) {
+    PasswordForm(
+        mode = PasswordFormMode.EDIT,
+        initial = EditListState(
+            name = args.password.name,
+            user = args.password.login,
+            password = args.password.password,
+            notes = args.password.notes
+        ),
+        onBack = navigateBack,
+        onSave = { updated -> savePassword(
+            args.password.copy(
+                name = updated.name,
+                login = updated.user,
+                password = updated.password,
+                notes = updated.notes
+            )
+        )}
+    )
+}
 
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PasswordForm(
+    mode: PasswordFormMode,
+    initial: EditListState = EditListState(),
+    onBack: () -> Unit,
+    onSave: (EditListState) -> Unit
+){
+    var name by rememberSaveable { mutableStateOf(initial.name) }
+    var user by rememberSaveable { mutableStateOf(initial.user) }
+    var password by rememberSaveable { mutableStateOf(initial.password) }
+    var notes by rememberSaveable { mutableStateOf(initial.notes) }
+
+    val title = when (mode) {
+        PasswordFormMode.CREATE -> "Criar nova senha"
+        PasswordFormMode.EDIT -> "Editar senha"
+    }
+
+    Scaffold(
+        topBar = { MyTopBar(title = title, onBack = onBack) }
+    ){ innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            EditInput(
+                textInputLabel = "Nome",
+                value = name,
+                onValueChange = { name = it },
+                imeAction = ImeAction.Next
+            )
+
+            EditInput(
+                textInputLabel = "Usuário",
+                value = user,
+                onValueChange = { user = it },
+                imeAction = ImeAction.Next
+            )
+
+            EditInput(
+                textInputLabel = "Senha",
+                value = password,
+                onValueChange = { password = it },
+                keyboardType = "password",
+                imeAction = ImeAction.Next
+            )
+
+            EditInput(
+                textInputLabel = "Notas",
+                value = notes,
+                onValueChange = { notes = it },
+                textInputHeight = 150,
+                keyboardType = "text",
+                imeAction = ImeAction.Done
+            )
+
+            Spacer(Modifier.height(24.dp))
+            Button(
+                onClick = { onSave(EditListState(name, user, password, notes)) },
+                colors = ButtonDefaults.buttonColors( containerColor = Lime)
+            ) {
+                Text("Salvar")
+            }
+
+        }
+    }
 }
 
 
 @Composable
 fun EditInput(
     textInputLabel: String,
-    textInputState: MutableState<String> = mutableStateOf(""),
-    textInputHeight: Int = 60
+    value: String,
+    onValueChange: (String) -> Unit,
+    textInputHeight: Int = 60,
+    keyboardType: String = "text",
+    imeAction: ImeAction = ImeAction.Default
 ) {
-    val padding: Int = 30
-
-    var textState by rememberSaveable { textInputState }
+    val padding = 30
+    var showPassword by rememberSaveable { mutableStateOf(false) }
+    val isPasswordField = keyboardType == "password"
 
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .height(textInputHeight.dp)
             .padding(horizontal = padding.dp),
-        horizontalArrangement = Arrangement.Center,
+        horizontalArrangement = Arrangement.Center
     ) {
         OutlinedTextField(
-            value = textState,
-            onValueChange = { textState = it },
+            value = value,
+            onValueChange = onValueChange,
             label = { Text(textInputLabel) },
             modifier = Modifier
                 .height(textInputHeight.dp)
-                .fillMaxWidth()
+                .fillMaxWidth(),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = when (keyboardType) {
+                    "text" -> KeyboardType.Text
+                    "number" -> KeyboardType.Number
+                    "password" -> KeyboardType.Password
+                    else -> KeyboardType.Text
+                },
+                imeAction = imeAction
+            ),
+            visualTransformation = if (isPasswordField && !showPassword) {
+                PasswordVisualTransformation()
+            } else {
+                VisualTransformation.None
+            },
+            trailingIcon = {
+                if (isPasswordField) {
+                    IconButton(onClick = { showPassword = !showPassword }) {
+                        Icon(
+                            imageVector =
+                                if (showPassword) Icons.Filled.VisibilityOff
+                                else Icons.Filled.Visibility,
+                            contentDescription = if (showPassword) "Ocultar senha" else "Mostrar senha"
+                        )
+                    }
+                }
+            }
         )
-
     }
+
     Spacer(modifier = Modifier.height(10.dp))
+}
+
+
+/* ===========================
+   PREVIEWS
+   =========================== */
+
+@Preview(showBackground = true, backgroundColor = 0xFF261307)
+@Composable
+fun AddPasswordPreview() {
+    PasswordForm(
+        mode = PasswordFormMode.CREATE,
+        onBack = {},
+        onSave = {}
+    )
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF261307)
+@Composable
+fun EditPasswordPreview() {
+    PasswordForm(
+        mode = PasswordFormMode.EDIT,
+        initial = EditListState(
+            name = "Facebook",
+            user = "devtitans",
+            password = "123",
+            notes = "Bla bla"
+        ),
+        onBack = {},
+        onSave = {}
+    )
 }
 
 @Preview(showBackground = true)
@@ -98,5 +270,5 @@ fun EditListPreview() {
 @Preview(showBackground = true)
 @Composable
 fun EditInputPreview() {
-    EditInput("Nome")
+    EditInput("Nome", "Usuário", {})
 }

--- a/PlainText/app/src/main/java/com/example/plaintext/ui/screens/util/MyTopBar.kt
+++ b/PlainText/app/src/main/java/com/example/plaintext/ui/screens/util/MyTopBar.kt
@@ -1,0 +1,49 @@
+package com.example.plaintext.ui.screens.util
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.plaintext.ui.theme.*
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MyTopBar(
+    title: String,
+    onBack: () -> Unit
+){
+    TopAppBar(
+        title = {
+            Text(
+                text = title,
+                fontSize = 20.sp,
+                color = Color.Black
+            )
+        },
+        navigationIcon = {
+            IconButton(onClick = onBack) {
+                Icon(
+                    Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Voltar",
+                    tint = Color.Black
+                )
+            }
+        },
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = Lime,
+            navigationIconContentColor = Color.Black,
+            titleContentColor = Color.Black
+        ),
+        modifier = Modifier.padding(bottom = 16.dp)
+    )
+}

--- a/PlainText/app/src/main/java/com/example/plaintext/ui/theme/Color.kt
+++ b/PlainText/app/src/main/java/com/example/plaintext/ui/theme/Color.kt
@@ -9,3 +9,5 @@ val Pink80 = Color(0xFFEFB8C8)
 val Purple40 = Color(0xFF6650a4)
 val PurpleGrey40 = Color(0xFF625b71)
 val Pink40 = Color(0xFF7D5260)
+
+val Lime = Color(0xFFA6D63B)


### PR DESCRIPTION
## Por que este PR é necessário? O que ele faz?


Este PR implementa a tela EditList com Compose, permitindo criar e editar senhas.
Principais pontos:

* Criação dos composables EditList e PasswordForm para manipulação de senhas.

* Componente reutilizável EditInput com suporte a texto, número e senha.

* Adicionado toggle de visibilidade de senha (olhinho).

* Inclusão de previews para os fluxos de criação e edição.

Fixes: #1

## Imagens


https://github.com/user-attachments/assets/5ca83884-073f-4512-b3d0-e706ae491c11

