### PR TITLE
feat: Add LoginViewModel skeleton

### DIFF
--- a/PlainText/app/src/main/java/com/example/plaintext/ui/screens/PlainTextApp.kt
+++ b/PlainText/app/src/main/java/com/example/plaintext/ui/screens/PlainTextApp.kt
@@ -13,34 +13,27 @@ import com.example.plaintext.utils.parcelableType
 import kotlin.reflect.typeOf
 
 @Composable
-fun PlainTextApp(
-    appState: PlainTextAppState = rememberPlainTextAppState()
-) {
-    NavHost(
-        navController = appState.navController,
-        startDestination = Screen.List,
-    ) {
-        composable<Screen.Hello> {
-            var args = it.toRoute<Screen.Hello>()
-            Hello_screen(args)
-        }
-        composable<Screen.Login> {
-            Login_screen(
-                navigateToSettings = {},
-                navigateToList = {}
-            )
-        }
-        composable<Screen.List> {
-            List_screen(appState)
-        }
-        composable<Screen.EditList>(
-            typeMap = mapOf(typeOf<PasswordInfo>() to parcelableType<PasswordInfo>())
-        ) {
-            val args = it.toRoute<Screen.EditList>()
-            Edit_screen(
-                args,
-                appState
-            )
-        }
+fun PlainTextApp(appState: PlainTextAppState = rememberPlainTextAppState()) {
+  NavHost(
+          navController = appState.navController,
+          startDestination = Screen.Login,
+  ) {
+    composable<Screen.Hello> {
+      var args = it.toRoute<Screen.Hello>()
+      Hello_screen(args)
     }
+    composable<Screen.Login> {
+      Login_screen(
+              navigateToSettings = { appState.navigateToSettings() },
+              navigateToList = { appState.navigateToListPasswords() }
+      )
+    }
+    composable<Screen.List> { List_screen(appState) }
+    composable<Screen.EditList>(
+            typeMap = mapOf(typeOf<PasswordInfo>() to parcelableType<PasswordInfo>())
+    ) {
+      val args = it.toRoute<Screen.EditList>()
+      Edit_screen(args, appState)
+    }
+  }
 }

--- a/PlainText/app/src/main/java/com/example/plaintext/ui/screens/PlainTextAppState.kt
+++ b/PlainText/app/src/main/java/com/example/plaintext/ui/screens/PlainTextAppState.kt
@@ -14,69 +14,56 @@ import kotlinx.serialization.Serializable
 @Serializable
 sealed class Screen() {
 
-    @Serializable
-    object Login;
+  @Serializable object Login
 
-    @Serializable
-    data class Hello(
-        val name: String?
-    )
+  @Serializable data class Hello(val name: String?)
 
-    @Serializable
-    object Preferences;
+  @Serializable object Preferences
 
-    @Serializable
-    object List
+  @Serializable object List
 
-    @Serializable
-    data class EditList(
-        val password: PasswordInfo
-    );
+  @Serializable data class EditList(val password: PasswordInfo)
 
-    @Serializable
-    object sensors;
+  @Serializable object sensors
 }
 
 @Composable
 fun rememberPlainTextAppState(
-    navController: NavHostController = rememberNavController(),
-    context: Context = LocalContext.current
-) = remember(navController, context) {
-    PlainTextAppState(navController, context)
-}
+        navController: NavHostController = rememberNavController(),
+        context: Context = LocalContext.current
+) = remember(navController, context) { PlainTextAppState(navController, context) }
 
+class PlainTextAppState(val navController: NavHostController, private val context: Context) {
 
-class PlainTextAppState(
-    val navController: NavHostController,
-    private val context: Context
-) {
+  fun checkRoute(route: String): Boolean {
+    val currentRoute = navController.currentBackStackEntry?.destination?.route.toString()
 
-    fun checkRoute(route: String): Boolean {
-        val currentRoute = navController.currentBackStackEntry?.destination?.route.toString()
+    return currentRoute != route
+  }
 
-        return currentRoute != route
-    }
+  fun navigateToHello(name: String?) {
+    navController.navigate(Screen.Hello(name))
+  }
 
-    fun navigateToHello(name: String?){
-        navController.navigate(Screen.Hello(name))
-    }
+  fun navigateToLogin() {
+    navController.navigate(Screen.Login)
+  }
 
-    fun navigateToLogin(){
-        navController.navigate(Screen.Login)
-    }
+  fun navigateToListPasswords() {
+    navController.navigate(Screen.List)
+  }
 
-    fun navigateToListPasswords(){
-        navController.navigate(Screen.List)
-    }
+  fun navigateToEditPassword(password: PasswordInfo) {
+    navController.navigate(Screen.EditList(password))
+  }
 
-    fun navigateToEditPassword(password: PasswordInfo){
-        navController.navigate(Screen.EditList(password))
-    }
+  fun navigateToSettings() {
+    navController.navigate(Screen.Preferences)
+  }
 
-    fun back(){
-        navController.popBackStack()
-    }
-
+  fun back() {
+    navController.popBackStack()
+  }
 }
 
 /**
@@ -85,4 +72,6 @@ class PlainTextAppState(
  * This is used to de-duplicate navigation events.
  */
 private fun NavBackStackEntry.lifecycleIsResumed() =
-    this.lifecycle.currentState == Lifecycle.State.RESUMED
+        this.lifecycle.currentState == Lifecycle.State.RESUMED
+
+this.lifecycle.currentState == Lifecycle.State.RESUMED

--- a/PlainText/app/src/main/java/com/example/plaintext/ui/screens/PlainTextAppState.kt
+++ b/PlainText/app/src/main/java/com/example/plaintext/ui/screens/PlainTextAppState.kt
@@ -74,4 +74,4 @@ class PlainTextAppState(val navController: NavHostController, private val contex
 private fun NavBackStackEntry.lifecycleIsResumed() =
         this.lifecycle.currentState == Lifecycle.State.RESUMED
 
-this.lifecycle.currentState == Lifecycle.State.RESUMED
+//this.lifecycle.currentState == Lifecycle.State.RESUMED

--- a/PlainText/app/src/main/java/com/example/plaintext/ui/screens/hello/Hello.kt
+++ b/PlainText/app/src/main/java/com/example/plaintext/ui/screens/hello/Hello.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 data class ListViewState(var listState: List<PasswordInfo> = emptyList(), var size: Int = 0)
 

--- a/PlainText/app/src/main/java/com/example/plaintext/ui/screens/hello/Hello.kt
+++ b/PlainText/app/src/main/java/com/example/plaintext/ui/screens/hello/Hello.kt
@@ -31,115 +31,97 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-data class ListViewState(
-    var listState: List<PasswordInfo> = emptyList(),
-    var size: Int = 0
-)
+data class ListViewState(var listState: List<PasswordInfo> = emptyList(), var size: Int = 0)
 
 @HiltViewModel
-class ListViewModel @Inject constructor(
-    private val passwordDBStore: PasswordDBStore
-) : ViewModel() {
-    var listState by mutableStateOf(ListViewState())
-        private set
-    private var dataList = mutableListOf<PasswordInfo>()
+class ListViewModel @Inject constructor(private val passwordDBStore: PasswordDBStore) :
+        ViewModel() {
+  var listState by mutableStateOf(ListViewState())
+    private set
+  private var dataList = mutableListOf<PasswordInfo>()
 
-    init {
-        viewModelScope.launch {
-            if (passwordDBStore.isEmpty().stateIn(viewModelScope).value) {
-                for (i in 1..100) {
-                    val p = PasswordInfo(
-                        i,
-                        "devtitans #$i",
-                        "devtitans #$i",
-                        "devtitans #$i",
-                        "devtitans #$i"
-                    )
-                    Log.d("ListViewModel", "Password: $p")
-                    passwordDBStore.add(p.toPassword())
-                }
-            }
-            dataList = passwordDBStore.getList().map { list ->
-                list.map { it.toPasswordInfo() }
-            }.stateIn(viewModelScope).value as MutableList<PasswordInfo>
-
-            dataList.forEach {
-                Log.d("ListViewModel", "Checking Password: $it")
-            }
-
-            collectData()
+  init {
+    viewModelScope.launch {
+      if (passwordDBStore.isEmpty().stateIn(viewModelScope).value) {
+        for (i in 1..100) {
+          val p =
+                  PasswordInfo(
+                          i,
+                          "devtitans #$i",
+                          "devtitans #$i",
+                          "devtitans #$i",
+                          "devtitans #$i"
+                  )
+          Log.d("ListViewModel", "Password: $p")
+          passwordDBStore.add(p.toPassword())
         }
-    }
+      }
+      dataList =
+              passwordDBStore
+                      .getList()
+                      .map { list -> list.map { it.toPasswordInfo() } }
+                      .stateIn(viewModelScope)
+                      .value as
+                      MutableList<PasswordInfo>
 
-    fun collectData() {
-        viewModelScope.launch {
-            Log.d("ListViewModel", "Collecting data")
-            delay(5000)
-            listState = ListViewState(dataList, dataList.size)
-            listState.listState.forEach {
-                Log.d("ListViewModel", "ListState Password: $it")
-            }
-        }
+      dataList.forEach { Log.d("ListViewModel", "Checking Password: $it") }
+
+      collectData()
     }
+  }
+
+  fun collectData() {
+    viewModelScope.launch {
+      Log.d("ListViewModel", "Collecting data")
+      delay(5000)
+      listState = ListViewState(dataList, dataList.size)
+      listState.listState.forEach { Log.d("ListViewModel", "ListState Password: $it") }
+    }
+  }
 }
 
 @Composable
 fun Hello_screen(modifier: Modifier, viewModel: ListViewModel = hiltViewModel()) {
-    val listViewState: ListViewState = viewModel.listState
+  val listViewState: ListViewState = viewModel.listState
 
-    Box(
-        modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center
-    ) {
-        if (listViewState.listState.isEmpty()) {
-            Text("Carregando...", fontSize = 20.sp)
-        } else {
-            Column() {
-                Text(
-                    text = "Total de itens: ${listViewState.size}",
+  Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    if (listViewState.listState.isEmpty()) {
+      Text("Carregando...", fontSize = 20.sp)
+    } else {
+      Column() {
+        Text(
+                text = "Total de itens: ${listViewState.size}",
+                fontSize = 20.sp,
+                modifier = Modifier.fillMaxWidth().background(Color.Red).padding(16.dp)
+        )
+        LazyColumn {
+          items(listViewState.listState.size) { index ->
+            Text(
+                    text = getPasswordAsText(listViewState, index),
                     fontSize = 20.sp,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(Color.Red)
-                        .padding(16.dp)
-                )
-                LazyColumn {
-                    items(listViewState.listState.size) { index ->
-                        Text(
-                            text = getPasswordAsText(listViewState, index),
-                            fontSize = 20.sp,
-                            modifier = Modifier
-                                .padding(16.dp)
-                                .fillMaxWidth()
-                        )
-                    }
-                }
-
-            }
-
+                    modifier = Modifier.padding(16.dp).fillMaxWidth()
+            )
+          }
         }
+      }
     }
+  }
 }
 
-private fun getPasswordAsText(
-    listViewState: ListViewState,
-    index: Int
-): String {
-    val pi = listViewState.listState[index]
-    val sb = StringBuilder()
-    sb.append("ID: ${pi.id}\n")
-    sb.append("Nome: ${pi.name}\n")
-    sb.append("Login: ${pi.login}\n")
-    sb.append("Pass: ${pi.password}\n")
-    sb.append("Notes: ${pi.notes}\n")
-    return sb.toString()
+private fun getPasswordAsText(listViewState: ListViewState, index: Int): String {
+  val pi = listViewState.listState[index]
+  val sb = StringBuilder()
+  sb.append("ID: ${pi.id}\n")
+  sb.append("Nome: ${pi.name}\n")
+  sb.append("Login: ${pi.login}\n")
+  sb.append("Pass: ${pi.password}\n")
+  sb.append("Notes: ${pi.notes}\n")
+  return sb.toString()
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun Hello_screen(args: Screen.Hello) {
-    Scaffold { padding ->
-        Hello_screen(Modifier.padding(padding))
-    }
+  Scaffold { padding -> Hello_screen(Modifier.padding(padding)) }
 }

--- a/PlainText/app/src/main/java/com/example/plaintext/ui/screens/login/Login.kt
+++ b/PlainText/app/src/main/java/com/example/plaintext/ui/screens/login/Login.kt
@@ -258,4 +258,3 @@ fun LoginScreenPreview() {
           viewModel = LoginViewModel() // Instância simples para o preview
   )
 }
-

--- a/PlainText/app/src/main/java/com/example/plaintext/ui/screens/login/Login.kt
+++ b/PlainText/app/src/main/java/com/example/plaintext/ui/screens/login/Login.kt
@@ -1,11 +1,7 @@
 package com.example.plaintext.ui.screens.login
 
-import android.util.Log
-import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -15,9 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.AlertDialog
@@ -28,255 +21,241 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview // Importante para o Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.plaintext.R
 import com.example.plaintext.ui.viewmodel.LoginViewModel // Importe o LoginViewModel
-import com.example.plaintext.ui.viewmodel.PreferencesViewModel
 
 // Removida a data class LoginState pois o ViewModel vai gerenciar isso
-
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun Login_screen(
-    navigateToSettings: () -> Unit,
-    navigateToList: (name: String) -> Unit, // Alterado para receber o nome
-    viewModel: LoginViewModel = hiltViewModel() // Injetando o LoginViewModel
+        navigateToSettings: () -> Unit,
+        navigateToList: () -> Unit, // Alterado para receber o nome
+        viewModel: LoginViewModel = hiltViewModel() // Injetando o LoginViewModel
 ) {
-    val context = LocalContext.current
-    var errorMessage by rememberSaveable { mutableStateOf<String?>(null) } // Estado para mensagem de erro
+  val context = LocalContext.current
+  var errorMessage by rememberSaveable {
+    mutableStateOf<String?>(null)
+  } // Estado para mensagem de erro
 
-    Scaffold(
-        topBar = {
+  Scaffold(
+          topBar = {
             TopBarComponent( // Reutilizando seu TopBarComponent existente
-                navigateToSettings = navigateToSettings,
-                navigateToSensores = { /* Não usado aqui, mas manter para compatibilidade */ }
+                    navigateToSettings = navigateToSettings,
+                    navigateToSensores = { /* Não usado aqui, mas manter para compatibilidade */}
             )
-        }
-    ) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-                .verticalScroll(rememberScrollState()) // Permite rolagem se o conteúdo for grande
-                .background(MaterialTheme.colorScheme.background), // Usando a cor de fundo do tema
+          }
+  ) { paddingValues ->
+    Column(
+            modifier =
+                    Modifier.fillMaxSize()
+                            .padding(paddingValues)
+                            .verticalScroll(
+                                    rememberScrollState()
+                            ) // Permite rolagem se o conteúdo for grande
+                            .background(
+                                    MaterialTheme.colorScheme.background
+                            ), // Usando a cor de fundo do tema
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
-        ) {
-            // Parte superior (verde escuro na imagem)
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(200.dp) // Altura fixa para a parte superior
-                    .background(Color(0xFF4CAF50)) // Cor verde similar à imagem (Material Green 500)
-                    .padding(16.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
-            ) {
-                Image(
-                    painter = painterResource(id = R.drawable.ic_launcher_foreground), // Substitua pelo seu ícone do Android
-                    contentDescription = "Android Icon",
-                    modifier = Modifier.width(70.dp).height(70.dp)
-                )
-                Text(
-                    text = stringResource(id = R.string.app_name), // Você pode definir o nome do app em strings.xml
-                    color = Color.White,
-                    fontSize = 20.sp,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.padding(top = 8.dp)
-                )
-                Text(
-                    text = "O mais seguro\ngerenciador de senhas\nBob and Alice",
-                    color = Color.White,
-                    textAlign = TextAlign.Center,
-                    fontSize = 14.sp
-                )
-            }
+    ) {
+      // Parte superior (verde escuro na imagem)
+      Column(
+              modifier =
+                      Modifier.fillMaxWidth()
+                              .height(200.dp) // Altura fixa para a parte superior
+                              .background(
+                                      Color(0xFF4CAF50)
+                              ) // Cor verde similar à imagem (Material Green 500)
+                              .padding(16.dp),
+              horizontalAlignment = Alignment.CenterHorizontally,
+              verticalArrangement = Arrangement.Center
+      ) {
+        Image(
+                painter =
+                        painterResource(
+                                id = R.drawable.ic_launcher_foreground
+                        ), // Substitua pelo seu ícone do Android
+                contentDescription = "Android Icon",
+                modifier = Modifier.width(70.dp).height(70.dp)
+        )
+        Text(
+                text =
+                        stringResource(
+                                id = R.string.app_name
+                        ), // Você pode definir o nome do app em strings.xml
+                color = Color.White,
+                fontSize = 20.sp,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 8.dp)
+        )
+        Text(
+                text = "O mais seguro\ngerenciador de senhas\nBob and Alice",
+                color = Color.White,
+                textAlign = TextAlign.Center,
+                fontSize = 14.sp
+        )
+      }
 
-            // Parte de baixo (formulário de login)
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 24.dp, vertical = 32.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(16.dp) // Espaço entre os elementos
-            ) {
-                Text(
-                    text = "Digite suas credenciais para continuar",
-                    style = MaterialTheme.typography.titleMedium,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.padding(bottom = 16.dp)
-                )
+      // Parte de baixo (formulário de login)
+      Column(
+              modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 32.dp),
+              horizontalAlignment = Alignment.CenterHorizontally,
+              verticalArrangement = Arrangement.spacedBy(16.dp) // Espaço entre os elementos
+      ) {
+        Text(
+                text = "Digite suas credenciais para continuar",
+                style = MaterialTheme.typography.titleMedium,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(bottom = 16.dp)
+        )
 
-                // Campo de Login
-                OutlinedTextField(
-                    value = viewModel.loginText,
-                    onValueChange = viewModel::onLoginTextChange,
-                    label = { Text("Login") },
-                    modifier = Modifier.fillMaxWidth(),
-                    isError = errorMessage != null // Indica erro se houver mensagem
-                )
+        // Campo de Login
+        OutlinedTextField(
+                value = viewModel.loginText,
+                onValueChange = viewModel::onLoginTextChange,
+                label = { Text("Login") },
+                modifier = Modifier.fillMaxWidth(),
+                isError = errorMessage != null // Indica erro se houver mensagem
+        )
 
-                // Campo de Senha
-                OutlinedTextField(
-                    value = viewModel.passwordText,
-                    onValueChange = viewModel::onPasswordTextChange,
-                    label = { Text("Senha") },
-                    visualTransformation = PasswordVisualTransformation(), // Para esconder a senha
-                    modifier = Modifier.fillMaxWidth(),
-                    isError = errorMessage != null // Indica erro se houver mensagem
-                )
+        // Campo de Senha
+        OutlinedTextField(
+                value = viewModel.passwordText,
+                onValueChange = viewModel::onPasswordTextChange,
+                label = { Text("Senha") },
+                visualTransformation = PasswordVisualTransformation(), // Para esconder a senha
+                modifier = Modifier.fillMaxWidth(),
+                isError = errorMessage != null // Indica erro se houver mensagem
+        )
 
-                // Exibir mensagem de erro, se houver
-                errorMessage?.let {
-                    Text(
-                        text = it,
-                        color = MaterialTheme.colorScheme.error,
-                        modifier = Modifier.fillMaxWidth(),
-                        textAlign = TextAlign.Start // Alinhar texto de erro à esquerda
-                    )
-                }
-
-                // Checkbox "Salvar informações de login"
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Checkbox(
-                        checked = viewModel.rememberMe,
-                        onCheckedChange = viewModel::onRememberMeChange
-                    )
-                    Text(text = "Salvar as informações de login")
-                }
-
-                Spacer(modifier = Modifier.height(24.dp)) // Espaço antes do botão
-
-                // Botão "Enviar"
-                Button(
-                    onClick = {
-                        errorMessage = null // Limpa erro anterior antes de tentar login
-                        viewModel.onLoginClick(
-                            onSuccess = {
-                                Log.d("LoginScreen", "Login bem-sucedido!")
-                                navigateToList(viewModel.loginText) // Navega com o nome de login
-                            },
-                            onError = { message ->
-                                errorMessage = message // Define a mensagem de erro
-                                Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
-                            }
-                        )
-                    },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .defaultMinSize(minHeight = 48.dp) // Altura mínima para o botão
-                ) {
-                    Text(text = "Enviar", fontSize = 18.sp)
-                }
-            }
+        // Exibir mensagem de erro, se houver
+        errorMessage?.let {
+          Text(
+                  text = it,
+                  color = MaterialTheme.colorScheme.error,
+                  modifier = Modifier.fillMaxWidth(),
+                  textAlign = TextAlign.Start // Alinhar texto de erro à esquerda
+          )
         }
+
+        // Checkbox "Salvar informações de login"
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+          Checkbox(checked = viewModel.rememberMe, onCheckedChange = viewModel::onRememberMeChange)
+          Text(text = "Salvar as informações de login")
+        }
+
+        Spacer(modifier = Modifier.height(24.dp)) // Espaço antes do botão
+
+        // Botão "Enviar"
+        Button(
+                onClick = {
+                  errorMessage = null // Limpa erro anterior antes de tentar login
+                  viewModel.onLoginClick(
+                          onSuccess = {
+                            Log.d("LoginScreen", "Login bem-sucedido!")
+                            // navigateToList(viewModel.loginText) // Navega com o nome de login
+                            navigateToList() // Navega com o nome de login
+                          },
+                          onError = { message ->
+                            errorMessage = message // Define a mensagem de erro
+                            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+                          }
+                  )
+                },
+                modifier =
+                        Modifier.fillMaxWidth()
+                                .defaultMinSize(minHeight = 48.dp) // Altura mínima para o botão
+        ) { Text(text = "Enviar", fontSize = 18.sp) }
+      }
     }
+  }
 }
 
 @Composable
 fun MyAlertDialog(shouldShowDialog: MutableState<Boolean>) {
-    if (shouldShowDialog.value) {
-        AlertDialog(
-            onDismissRequest = {
-                shouldShowDialog.value = false
-            },
-
+  if (shouldShowDialog.value) {
+    AlertDialog(
+            onDismissRequest = { shouldShowDialog.value = false },
             title = { Text(text = "Sobre") },
             text = { Text(text = "PlainText Password Manager v1.0") },
             confirmButton = {
-                Button(
-                    onClick = { shouldShowDialog.value = false }
-                ) {
-                    Text(text = "Ok")
-                }
+              Button(onClick = { shouldShowDialog.value = false }) { Text(text = "Ok") }
             }
-        )
-    }
+    )
+  }
 }
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 fun TopBarComponent(
-    navigateToSettings: (() -> Unit?)? = null,
-    navigateToSensores: (() -> Unit?)? = null,
+        navigateToSettings: (() -> Unit?)? = null,
+        navigateToSensores: (() -> Unit?)? = null,
 ) {
-    var expanded by remember { mutableStateOf(false) }
-    val shouldShowDialog = remember { mutableStateOf(false) }
+  var expanded by remember { mutableStateOf(false) }
+  val shouldShowDialog = remember { mutableStateOf(false) }
 
-    if (shouldShowDialog.value) {
-        MyAlertDialog(shouldShowDialog = shouldShowDialog)
-    }
+  if (shouldShowDialog.value) {
+    MyAlertDialog(shouldShowDialog = shouldShowDialog)
+  }
 
-    TopAppBar(
-        title = { Text("PlainText") },
-        actions = {
+  TopAppBar(
+          title = { Text("PlainText") },
+          actions = {
             IconButton(onClick = { expanded = true }) {
-                Icon(Icons.Default.MoreVert, contentDescription = "Menu")
+              Icon(Icons.Default.MoreVert, contentDescription = "Menu")
             }
-            DropdownMenu(
-                expanded = expanded,
-                onDismissRequest = { expanded = false }
-            ) {
-                DropdownMenuItem(
-                    text = { Text("Configurações") },
-                    onClick = {
-                        navigateToSettings?.invoke(); // Chamar se não for nulo
-                        expanded = false;
-                    },
-                    modifier = Modifier.padding(8.dp)
-                )
-                DropdownMenuItem(
-                    text = {
-                        Text("Sobre");
-                    },
-                    onClick = {
-                        shouldShowDialog.value = true;
-                        expanded = false;
-                    },
-                    modifier = Modifier.padding(8.dp)
-                )
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+              DropdownMenuItem(
+                      text = { Text("Configurações") },
+                      onClick = {
+                        navigateToSettings?.invoke() // Chamar se não for nulo
+                        expanded = false
+                      },
+                      modifier = Modifier.padding(8.dp)
+              )
+              DropdownMenuItem(
+                      text = { Text("Sobre") },
+                      onClick = {
+                        shouldShowDialog.value = true
+                        expanded = false
+                      },
+                      modifier = Modifier.padding(8.dp)
+              )
             }
-        }
-    )
+          }
+  )
 }
 
 // Função de Preview para a Login_screen
 @Preview(showBackground = true, widthDp = 360)
 @Composable
 fun LoginScreenPreview() {
-    // Para o Preview, podemos passar lambdas vazios ou mockados
-    Login_screen(
-        navigateToSettings = { Log.d("Preview", "Navegar para Configurações (Preview)") },
-        navigateToList = { name -> Log.d("Preview", "Navegar para Lista com nome: $name (Preview)") },
-        viewModel = LoginViewModel() // Instância simples para o preview
-    )
+  // Para o Preview, podemos passar lambdas vazios ou mockados
+  Login_screen(
+          navigateToSettings = { Log.d("Preview", "Navegar para Configurações (Preview)") },
+          navigateToList = { name ->
+            Log.d("Preview", "Navegar para Lista com nome: $name (Preview)")
+          },
+          viewModel = LoginViewModel() // Instância simples para o preview
+  )
 }
+

--- a/PlainText/app/src/main/java/com/example/plaintext/ui/screens/login/Login.kt
+++ b/PlainText/app/src/main/java/com/example/plaintext/ui/screens/login/Login.kt
@@ -1,7 +1,10 @@
 package com.example.plaintext.ui.screens.login
 
+import android.util.Log
+import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -11,6 +14,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.AlertDialog
@@ -21,6 +26,8 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -29,11 +36,14 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview // Importante para o Preview
@@ -252,9 +262,7 @@ fun LoginScreenPreview() {
   // Para o Preview, podemos passar lambdas vazios ou mockados
   Login_screen(
           navigateToSettings = { Log.d("Preview", "Navegar para Configurações (Preview)") },
-          navigateToList = { name ->
-            Log.d("Preview", "Navegar para Lista com nome: $name (Preview)")
-          },
+          navigateToList = { Log.d("Preview", "Navegar para Lista com nome: (Preview)") },
           viewModel = LoginViewModel() // Instância simples para o preview
   )
 }

--- a/PlainText/app/src/main/java/com/example/plaintext/ui/viewmodel/LoginViewModel.backup
+++ b/PlainText/app/src/main/java/com/example/plaintext/ui/viewmodel/LoginViewModel.backup
@@ -1,0 +1,61 @@
+package com.example.plaintext.ui.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+data class LoginState(
+        var salvarLogin: Boolean = false,
+        var login: String = "",
+        val navigateToSettings: () -> Unit = {},
+        val navigateToList: (name: String) -> Unit = {},
+        val checkCredentials: (login: String, password: String) -> Boolean = { _, _ -> true },
+)
+
+@HiltViewModel
+class LoginViewModel @Inject constructor() : ViewModel() {
+
+  // O estado privado e o estado público para o Composable
+  var loginState by mutableStateOf(LoginState())
+    private set
+
+  // Campos de texto e estado de salvamento
+  var login = mutableStateOf("")
+  var senha = mutableStateOf("")
+  var salvarLogin = mutableStateOf(false)
+
+  init {
+    // atribui login para o valor padrão definido nas preferencias
+    loginState = loginState.copy(login = getDefaultLoginFromPreferences())
+  }
+
+  fun getDefaultLoginFromPreferences(): String {
+    // TODO: Buscar o valor padrão nas preferências
+    return "default login"
+  }
+
+  fun onLoginClick() {
+    viewModelScope.launch {
+      // Simular uma verificação assíncrona
+      delay(200)
+      if (loginState.checkCredentials(login.value, senha.value)) {
+        // Atualizar a função de navegação
+        loginState.navigateToList(login.value)
+      } else {
+        // Mostra um toast com a mensagem de credenciais invalidas
+        println("Credenciais inválidas")
+      }
+    }
+  }
+
+  // Função para atualizar o estado com base nas ações de navegação do Composable
+  fun updateLoginState(newState: LoginState) {
+    loginState = newState
+  }
+}

--- a/PlainText/app/src/main/java/com/example/plaintext/ui/viewmodel/LoginViewmodel.kt
+++ b/PlainText/app/src/main/java/com/example/plaintext/ui/viewmodel/LoginViewmodel.kt
@@ -10,38 +10,39 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginViewModel @Inject constructor() : ViewModel() {
 
-    var loginText by mutableStateOf("")
-        private set
+  var loginText by mutableStateOf("")
+    private set
 
-    var passwordText by mutableStateOf("")
-        private set
+  var passwordText by mutableStateOf("")
+    private set
 
-    var rememberMe by mutableStateOf(false)
-        private set
+  var rememberMe by mutableStateOf(false)
+    private set
 
-    fun onLoginTextChange(newText: String) {
-        loginText = newText
+  fun onLoginTextChange(newText: String) {
+    loginText = newText
+  }
+
+  fun onPasswordTextChange(newText: String) {
+    passwordText = newText
+  }
+
+  fun onRememberMeChange(checked: Boolean) {
+    rememberMe = checked
+  }
+
+  // Esta função será para a lógica de autenticação real.
+  // Por enquanto, apenas um log simples.
+  fun onLoginClick(onSuccess: () -> Unit, onError: (message: String) -> Unit) {
+    // Logica de autenticação ficará aqui
+
+    if (loginText == "admin" && passwordText == "password") {
+      // Sucesso
+      onSuccess()
+    } else {
+      // Falha
+      onError("Login ou senha inválidos.")
     }
-
-    fun onPasswordTextChange(newText: String) {
-        passwordText = newText
-    }
-
-    fun onRememberMeChange(checked: Boolean) {
-        rememberMe = checked
-    }
-
-    // Esta função será para a lógica de autenticação real.
-    // Por enquanto, apenas um log simples.
-    fun onLoginClick(onSuccess: () -> Unit, onError: (message: String) -> Unit) {
-        // Logica de autenticação ficará aqui
-
-        if (loginText == "admin" && passwordText == "password") {
-            // Sucesso
-            onSuccess()
-        } else {
-            // Falha
-            onError("Login ou senha inválidos.")
-        }
-    }
+  }
 }
+


### PR DESCRIPTION
## Por que este PR é necessário? O que ele faz?
- Adiciona o viewModel da tela de login
- Utiliza a dataclass fornecida no repositório inicial:
```kotlin
data class LoginState(
        var salvarLogin: Boolean = false,
        var login: String = "",
        val navigateToSettings: () -> Unit = {},
        val navigateToList: (name: String) -> Unit = {},
        val checkCredentials: (login: String, password: String) -> Boolean = { _, _ -> true },
)
````
- Ainda não está 100% concluída visto que essa viewModel deve ser utilizada em outras task e modificada de acordo com as necessidades:
-  Essa viewModel deve ser utilizada nas atividades
      - Autenticação
      - LoginComposable
- Ainda falta fazer:
-  [ ] Atualizar a função de checagem de credencials (Autenticação)
-  [ ] Pegar o login padrão da tela de preferencias se a opção "salvar login" estiver preenchida
-  [ ] Atualizar o LoginComposable para utilizar as funções da LoginViewModel
    
Fixes: # https://github.com/users/NBO2001/projects/3/views/1?pane=issue&itemId=128567563

## Como Testar
- Basta abrir no android studio e clicar no botão de executar
- Tive que fazer umas alterações de ui e navegação pra testar a viewmodel e possibilitar este teste
