### PR TITLE
Não permitir voltar para a tela de Login se já estiver logado

### DIFF
--- a/PlainText/app/src/main/java/com/example/plaintext/ui/screens/list/ListPasswords.kt
+++ b/PlainText/app/src/main/java/com/example/plaintext/ui/screens/list/ListPasswords.kt
@@ -25,6 +25,9 @@ import com.example.plaintext.data.model.PasswordInfo
 import com.example.plaintext.ui.screens.PlainTextAppState
 import com.example.plaintext.ui.viewmodel.ListPasswordsViewModel
 import com.example.plaintext.ui.viewmodel.ListViewState
+import androidx.activity.compose.BackHandler
+import android.widget.Toast
+import androidx.compose.ui.platform.LocalContext
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -33,6 +36,12 @@ fun List_screen(
     viewModel: ListPasswordsViewModel = hiltViewModel()
 ) {
     val listState = viewModel.listViewState
+    val context = LocalContext.current
+    val message = stringResource(R.string.disabled_back_button)
+
+    BackHandler(enabled = true) {
+        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+    }
 
     Scaffold(
         topBar = {

--- a/PlainText/app/src/main/res/values/strings.xml
+++ b/PlainText/app/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
     <string name="no_passwords_found">No Passwords found</string>
     <string name="add_password_prompt">Add Password Prompt</string>
     <string name="save">Save</string>
+    <string name="disabled_back_button">Back button disabled on this screen</string>
 </resources>


### PR DESCRIPTION
- Botão de voltar desabilitado na view de listagem de senhas.
- Adicionei menssagem Toast.

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/0ac8b630-8b19-4b77-861b-6356a3287321" />

Fixes:  #18
